### PR TITLE
fix dead link on prerequisites.adoc

### DIFF
--- a/docs/prerequisites.adoc
+++ b/docs/prerequisites.adoc
@@ -30,7 +30,7 @@ endif::[]
 
 This section will guide you through the pre-requisites before you can use this project.
 
-You can proceed to the xref:docs/quickstart.adoc[Quick Start guide] if you have already done these steps.
+You can proceed to the xref:quickstart.adoc[Quick Start guide] if you have already done these steps.
 
 toc::[]
 


### PR DESCRIPTION
prerequisites.adoc have a link to quickstart.adoc.
Both files are in the same folder, an erroneous `doc/` is present and needs to be removed.
