### PR TITLE
Feat: add Pull Requests template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -22,12 +22,12 @@ Please include a summary of the change and which issue is fixed in the form of f
 If your are running automated testing for this module, we would love to hear from you, and potentially integrate it to the module standard workflow.
 
 <!---
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+Please describe the tests that you ran to verify your changes and provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 --->
 
 ### Manual testing
 
-If no automated testing is run, please ensure that al least the three steps below are passing without any error.
+If no automated testing is run, please ensure that at least the three steps below are passing without any error.
 
 - [ ] Running `terraform apply` on each examples of this module provision the intended resources without any error
 - [ ] Modifying module Input Variables after initial provisioning act as intended: updatable properties gets updated without a resource recreate
@@ -42,3 +42,5 @@ If no automated testing is run, please ensure that al least the three steps belo
 - [ ] I updated all examples, including their README files and sample code blocks in it
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published in downstream modules
+
+Note: *If you are not an Oracle employee, to contribute to an Oracle-sponsored open-source project, you need to sign the [Oracle Contributor Agreement (OCA)](https://oca.opensource.oracle.com/).*

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,25 +1,23 @@
 # Proposed change
 
 <!--- 
-Please include a summary of the change and which issue is fixed in the form of fix #XX for auto-linking.
 
-- Include relevant motivation and context
-- List any dependencies that are required for this change.
+Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add. Discussing the design upfront helps to ensure that we're ready to accept your work.
+
+The subject of your PR should denote the type of change, i.e: `fix: ...` or `feat: ...`.
+
+Please include a summary of this contribution. If there is an existing issue related to this change, your PR description should auto-link it using these keywords:
+
+- for a bug fix, use `fix` keyword, i.e: `fix #000`
+- for a new feature, use `close `keword, i.e: `close #000`
+
 --->
 
-## Type of change
-
-<!--- Please delete options that are not relevant for your change --->
-
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
-## How has this change been tested?
+## How has these changes been tested?
 
 ### Automated testing
 
-If your are running automated testing for this module, we would love to hear from you, and potentially integrate it to the module standard workflow.
+If you're running automated testing for this module, we would love to hear from you, and potentially integrate it to the module standard workflow.
 
 <!---
 Please describe the tests that you ran to verify your changes and provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
@@ -29,18 +27,21 @@ Please describe the tests that you ran to verify your changes and provide instru
 
 If no automated testing is run, please ensure that at least the three steps below are passing without any error.
 
-- [ ] Running `terraform apply` on each examples of this module provision the intended resources without any error
-- [ ] Modifying module Input Variables after initial provisioning act as intended: updatable properties gets updated without a resource recreate
-- [ ] Running `terraform destroy` on each examples of this module destroy all and only the resources created by this module
+- [ ] Running `terraform apply` on each example provided with this module provisions the intended resource(s) without any errors.
+- [ ] Modifying module's *Input Variables* after initial provisioning behaves as intended, i.e: any updateable properties are ameneded without recreation of the resource(s).
+- [ ] Running `terraform destroy` on each example provided with this module destroys all the resources created by this module and only the resources created by this module.
 
 ## Checklist before submitting your PR
 
 - [ ] My code follows [the style guidelines of this project](../tree/main/docs/codingconventions.adoc)
-- [ ] If contribution provision new resources, I updated the README introduction section (both adoc and md versions)
-- [ ] If contribution adds any new variables, I updated [docs/terraformoptions.adoc](../tree/main/docs/terraformoptions.adoc)
-- [ ] I added an entry that explains the fix or enhancement to the list of unreleased items in CHANGELOG
-- [ ] I updated all examples, including their README files and sample code blocks in it
-- [ ] My changes generate no new warnings
-- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] these changes provision new resources:
+  - [ ] I have updated the README introduction section (README.adoc)
+  - [ ] I have updated the README introduction section (README.md)
+- [ ] these changes adds any new variables:
+  - [ ] I have updated [docs/terraformoptions.adoc](../tree/main/docs/terraformoptions.adoc) to include each variable
+- [ ] I have updated the changelog to include an entry for these changes
+- [ ] I have updated all provided examples, including each README file and all applicable code blocks
+- [ ] these changes generates no new warnings
+- [ ] Any dependent changes have been merged and published in upstream modules
 
 Note: *If you are not an Oracle employee, to contribute to an Oracle-sponsored open-source project, you need to sign the [Oracle Contributor Agreement (OCA)](https://oca.opensource.oracle.com/).*

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,43 @@
+# Proposed change
+
+<!--- 
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+--->
+
+Fixed issues: <!--insert issue reference in this form: #XX #XX-->
+
+## Type of change
+
+<!--- Please delete options that are not relevant for your change --->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## How has this change been tested?
+
+### Automated testing
+
+If your are running automated testing for this module, we would love to hear from you, and potentially integrate it to the module standard workflow.
+
+<!---
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+--->
+
+### Manual testing
+
+If no automated testing is run, please ensure that al least the three steps below are passing without any error.
+
+- [ ] Running `terraform apply` on each examples of this module provision the intended resources without any error
+- [ ] Modifying module Input Variables after initial provisioning act as intended: updatable properties gets updated without a resource recreate
+- [ ] Running `terraform destroy` on each examples of this module destroy all and only the resources created by this module
+
+## Checklist before submitting your PR
+
+- [ ] My code follows [the style guidelines of this project](../tree/main/docs/codingconventions.adoc)
+- [ ] If contribution provision new resources, I updated the README introduction section (both adoc and md versions)
+- [ ] If contribution adds any new variables, I updated [docs/terraformoptions.adoc](../tree/main/docs/terraformoptions.adoc)
+- [ ] I added an entry that explains the fix or enhancement to the list of unreleased items in CHANGELOG
+- [ ] I updated all examples, including their README files and sample code blocks in it
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,18 +1,19 @@
 # Proposed change
 
 <!--- 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
---->
+Please include a summary of the change and which issue is fixed in the form of fix #XX for auto-linking.
 
-Fixed issues: <!--insert issue reference in this form: #XX #XX-->
+- Include relevant motivation and context
+- List any dependencies that are required for this change.
+--->
 
 ## Type of change
 
 <!--- Please delete options that are not relevant for your change --->
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ## How has this change been tested?
 


### PR DESCRIPTION
the PR template is customized for Terraform workflow and adapted to our current code organization, calling out for specific actions before submitting a PR in the form of checklists:

- proposed change description
- type of change checkbox
- testing checklist
- documentation update checklist

The content is generic enough to be adopted by each Terraform modules we maintain.

Later, we could enforce a PR Check using GitHub Actions to ensure every checklist are cleared before allowing code 
merge.

Fix #33 