### PR TITLE
feat: add support for multiple CIDR

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,13 +17,21 @@ Given a version number MAJOR.MINOR.PATCH:
 == v3.0.0 (Unreleased)
 
 === Breaking changes
-* Set minimum Terraform version to 1.0.0 (fixes #49)
+* Changed minimum Terraform version to 1.0.0 (fixes #49)
+* Deprecated `vcn_cidr`, use `vcn_cidrs` instead (list of IPv4 CIDRs).
+* [ ] Deprecated previous gateway creation variable names. We now use imperative style, see codingconventions (fixes #24)
 
 === New features
 * added support for local peering gateways (fixes #38)
+* added support for multiple CIDR (fixes #21)
+* [ ] added custom display name for gateways and drg attachment (fixes #30 and #44)
+
+=== Fixes
+* Fixed description for var.local_peering_gateways (fixes #51)
 
 === Other minor changes
 * Updated default tag values
+* Updated all examples to use the new `vcn_cidrs` module Input Variable instead of the now deprecated `vcn_cidr`
 
 == v2.3.0 (July 21, 2021)
 

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ The {uri-repo}[Terraform VCN] for {uri-oci}[Oracle Cloud Infrastructure] (OCI) p
 
 It creates the following resources:
 
-* A VCN with customizable CIDR block
+* A VCN with one or more customizable CIDR blocks
 * An optional internet gateway and a route table
 * An optional NAT gateway and a route table
 * An optional service gateway

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The [Terraform VCN][repo] for [Oracle Cloud Infrastructure][OCI] provides a reus
 
 It creates the following resources:
 
-* A VCN with customizable CIDR block
+* A VCN with one or more customizable CIDR blocks
 * An optional internet gateway and a route table
 * An optional NAT gateway
 * An optional service gateway

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -102,7 +102,7 @@ tags = {
 |null
 
 |`local_peering_gateways`
-|List of Local Peering Gateways to attach to the VCN
+|Map of Local Peering Gateways to attach to the VCN
 | e.g.
 [source]
 ----
@@ -163,7 +163,12 @@ tags = {
 |false
 
 |`vcn_cidr`
-|The VCN's CIDR block. The CIDR block specified for the VCN must not overlap with the CIDR block of another network.
+|DEPRECATED: The VCN's CIDR block. Please use `vcn_cidrs` instead.
+|
+|10.0.0.0/16
+
+|`vcn_cidrs`
+|The list of IPv4 CIDR blocks the VCN will use. The CIDR block specified for the VCN must not overlap with the CIDR block of another network.
 |
 |10.0.0.0/16
 

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -162,11 +162,6 @@ tags = {
 |true/false
 |false
 
-|`vcn_cidr`
-|DEPRECATED: The VCN's CIDR block. Please use `vcn_cidrs` instead.
-|
-|10.0.0.0/16
-
 |`vcn_cidrs`
 |The list of IPv4 CIDR blocks the VCN will use. The CIDR block specified for the VCN must not overlap with the CIDR block of another network.
 |

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -164,8 +164,12 @@ tags = {
 
 |`vcn_cidrs`
 |The list of IPv4 CIDR blocks the VCN will use. The CIDR block specified for the VCN must not overlap with the CIDR block of another network.
-|
-|10.0.0.0/16
+|e.g.
+[source]
+----
+["10.0.0.0/16", "172.16.0.0/16", "192.168.0.0/16"]
+----
+| `["10.0.0.0/16"]`
 
 |`vcn_dns_label`
 |The internal DNS domain for resources created and prepended to "oraclevcn.com" which is the VCN-internal domain name. *Required*

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,7 +77,7 @@ module "vcn" {
   create_drg               = var.create_drg
   drg_display_name         = var.drg_display_name
   tags                     = var.tags
-  vcn_cidr                 = var.vcn_cidr
+  vcn_cidrs                = var.vcn_cidrs
   vcn_dns_label            = var.vcn_dns_label
   vcn_name                 = var.vcn_name
   lockdown_default_seclist = var.lockdown_default_seclist

--- a/examples/custom_route_rules/main.tf
+++ b/examples/custom_route_rules/main.tf
@@ -17,7 +17,7 @@ terraform {
 
 module "vcn" {
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "2.2.0"
+  version = "3.0.0-RC2"
 
   # general oci parameters
   compartment_id = var.compartment_id
@@ -30,7 +30,7 @@ module "vcn" {
   lockdown_default_seclist = var.lockdown_default_seclist # boolean: true or false
   nat_gateway_enabled      = var.nat_gateway_enabled      # boolean: true or false
   service_gateway_enabled  = var.service_gateway_enabled  # boolean: true or false
-  vcn_cidr                 = var.vcn_cidr                 # VCN CIDR
+  vcn_cidrs                = var.vcn_cidrs                # List of IPv4 CIDRs
   vcn_dns_label            = var.vcn_dns_label
   vcn_name                 = var.vcn_name
 

--- a/examples/custom_route_rules/terraform.tfvars.example
+++ b/examples/custom_route_rules/terraform.tfvars.example
@@ -29,7 +29,7 @@ nat_gateway_enabled = false
 
 service_gateway_enabled = false
 
-vcn_cidr = "10.0.0.0/16"
+vcn_cidrs = ["10.0.0.0/16"]
 
 vcn_dns_label = "vcn"
 

--- a/examples/custom_route_rules/variables.tf
+++ b/examples/custom_route_rules/variables.tf
@@ -88,10 +88,10 @@ variable "tags" {
   }
 }
 
-variable "vcn_cidr" {
-  description = "cidr block of VCN"
-  type        = string
-  default     = "10.0.0.0/16"
+variable "vcn_cidrs" {
+  description = "The list of IPv4 CIDR blocks the VCN will use."
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
 }
 
 variable "vcn_dns_label" {
@@ -145,7 +145,7 @@ locals {
       destination       = "203.0.113.0/24" # rfc5737 (TEST-NET-3)
       destination_type  = "CIDR_BLOCK"
       network_entity_id = "nat_gateway"
-      description       = "Terraformed - User added Routing Rule: To NAT Gateway created by this module. nat_gateway_id is automatically retrieved with keyword nat_gateway"
+      description       = "Terraformed - User added Routing Rule: rfc5737 (TEST-NET-3) To NAT Gateway created by this module. nat_gateway_id is automatically retrieved with keyword nat_gateway"
     },
     {
       destination       = "192.168.1.0/24"

--- a/examples/hub-spoke/README.md
+++ b/examples/hub-spoke/README.md
@@ -21,7 +21,7 @@ Three VCN will be created:
 
 This diagram illustrates what will be created by this example.
 
-![diagram](https://github.com/oracle-terraform-modules/terraform-oci-vcn/blob/main/docs/hub-spoke/images/hub-spoke-lpg.PNG?raw=true&sanitize=true)
+![diagram](https://github.com/oracle-terraform-modules/terraform-oci-vcn/blob/main/docs/images/hub-spoke/hub-spoke-lpg.PNG?raw=true&sanitize=true)
 
 ## How to declare one or many LPG on the vcn module
 

--- a/examples/hub-spoke/main.tf
+++ b/examples/hub-spoke/main.tf
@@ -18,7 +18,7 @@ terraform {
 module "vcn_hub" {
   # this module use the generic vcn module and configure it to act as a hub in a hub-and-spoke topology 
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "2.4.0" # this is the first version supporting the LPG feature. Feel free to adjust for a newer version or remove the `version` line to get the latest version each time. 
+  version = "3.0.0-RC2"
 
   # general oci parameters
   compartment_id = var.compartment_id
@@ -31,7 +31,7 @@ module "vcn_hub" {
   lockdown_default_seclist = var.lockdown_default_seclist # boolean: true or false
   nat_gateway_enabled      = var.nat_gateway_enabled      # boolean: true or false
   service_gateway_enabled  = var.service_gateway_enabled  # boolean: true or false
-  vcn_cidr                 = var.vcn_cidr                 # VCN CIDR
+  vcn_cidrs                = var.vcn_cidrs                # List of IPv4 CIDRs
   vcn_dns_label            = var.vcn_dns_label
   vcn_name                 = var.vcn_name
 
@@ -61,7 +61,7 @@ resource "oci_core_route_table" "VTR_spokes" {
 module "vcn_spoke1" {
   # this module use the generic vcn module and configure it to act as a spoke in a hub-and-spoke topology 
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "2.4.0" # this is the first version supporting the LPG feature. Feel free to adjust for a newer version or remove the `version` line to get the latest version each time. 
+  version = "3.0.0-RC2"
 
   # general oci parameters
   compartment_id = var.compartment_id
@@ -69,12 +69,12 @@ module "vcn_spoke1" {
   tags           = var.tags
 
   # vcn parameters
-  create_drg               = false         # boolean: true or false
-  internet_gateway_enabled = false         # boolean: true or false
-  lockdown_default_seclist = true          # boolean: true or false
-  nat_gateway_enabled      = false         # boolean: true or false
-  service_gateway_enabled  = false         # boolean: true or false
-  vcn_cidr                 = "10.0.1.0/24" # VCN CIDR
+  create_drg               = false           # boolean: true or false
+  internet_gateway_enabled = false           # boolean: true or false
+  lockdown_default_seclist = true            # boolean: true or false
+  nat_gateway_enabled      = false           # boolean: true or false
+  service_gateway_enabled  = false           # boolean: true or false
+  vcn_cidrs                = ["10.0.1.0/24"] # VCN CIDR
   vcn_dns_label            = "fraspoke1"
   vcn_name                 = "spoke1"
 
@@ -90,7 +90,7 @@ module "vcn_spoke1" {
 module "vcn_spoke2" {
   # this module use the generic vcn module and configure it to act as a spoke in a hub-and-spoke topology 
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "2.4.0" # this is the first version supporting the LPG feature. Feel free to adjust for a newer version or remove the `version` line to get the latest version each time. 
+  version = "3.0.0-RC2"
 
   # general oci parameters
   compartment_id = var.compartment_id
@@ -98,12 +98,12 @@ module "vcn_spoke2" {
   tags           = var.tags
 
   # vcn parameters
-  create_drg               = false         # boolean: true or false
-  internet_gateway_enabled = false         # boolean: true or false
-  lockdown_default_seclist = true          # boolean: true or false
-  nat_gateway_enabled      = false         # boolean: true or false
-  service_gateway_enabled  = false         # boolean: true or false
-  vcn_cidr                 = "10.0.2.0/24" # VCN CIDR
+  create_drg               = false           # boolean: true or false
+  internet_gateway_enabled = false           # boolean: true or false
+  lockdown_default_seclist = true            # boolean: true or false
+  nat_gateway_enabled      = false           # boolean: true or false
+  service_gateway_enabled  = false           # boolean: true or false
+  vcn_cidrs                = ["10.0.2.0/24"] # VCN CIDR
   vcn_dns_label            = "fraspoke2"
   vcn_name                 = "spoke2"
 
@@ -117,7 +117,7 @@ module "vcn_spoke2" {
 module "vcn_spoke3" {
   # this module use the generic vcn module and configure it to act as a spoke in a hub-and-spoke topology 
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "2.4.0" # this is the first version supporting the LPG feature. Feel free to adjust for a newer version or remove the `version` line to get the latest version each time. 
+  version = "3.0.0-RC2"
 
   # general oci parameters
   compartment_id = var.compartment_id
@@ -125,12 +125,12 @@ module "vcn_spoke3" {
   tags           = var.tags
 
   # vcn parameters
-  create_drg               = false         # boolean: true or false
-  internet_gateway_enabled = false         # boolean: true or false
-  lockdown_default_seclist = true          # boolean: true or false
-  nat_gateway_enabled      = false         # boolean: true or false
-  service_gateway_enabled  = false         # boolean: true or false
-  vcn_cidr                 = "10.0.3.0/24" # VCN CIDR
+  create_drg               = false           # boolean: true or false
+  internet_gateway_enabled = false           # boolean: true or false
+  lockdown_default_seclist = true            # boolean: true or false
+  nat_gateway_enabled      = false           # boolean: true or false
+  service_gateway_enabled  = false           # boolean: true or false
+  vcn_cidrs                = ["10.0.3.0/24"] # VCN CIDR
   vcn_dns_label            = "fraspoke3"
   vcn_name                 = "spoke3"
 

--- a/examples/hub-spoke/terraform.tfvars.example
+++ b/examples/hub-spoke/terraform.tfvars.example
@@ -29,7 +29,7 @@ nat_gateway_enabled = false
 
 service_gateway_enabled = false
 
-vcn_cidr = "10.0.0.0/16"
+vcn_cidrs = ["10.0.0.0/24"]
 
 vcn_dns_label = "vcn"
 

--- a/examples/hub-spoke/variables.tf
+++ b/examples/hub-spoke/variables.tf
@@ -88,10 +88,10 @@ variable "tags" {
   }
 }
 
-variable "vcn_cidr" {
-  description = "cidr block of VCN"
-  type        = string
-  default     = "10.0.0.0/16"
+variable "vcn_cidrs" {
+  description = "The list of IPv4 CIDR blocks the VCN will use."
+  type        = list(string)
+  default     = ["10.0.0.0/24"]
 }
 
 variable "vcn_dns_label" {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -29,7 +29,7 @@ module "vcn" {
   lockdown_default_seclist = var.lockdown_default_seclist # boolean: true or false
   nat_gateway_enabled      = var.nat_gateway_enabled      # boolean: true or false
   service_gateway_enabled  = var.service_gateway_enabled  # boolean: true or false
-  vcn_cidr                 = var.vcn_cidr                 # VCN CIDR
+  vcn_cidrs                = var.vcn_cidrs                # List of IPv4 CIDRs
   vcn_dns_label            = var.vcn_dns_label
   vcn_name                 = var.vcn_name
 

--- a/examples/terraform.tfvars.example
+++ b/examples/terraform.tfvars.example
@@ -29,11 +29,13 @@ nat_gateway_enabled = false
 
 service_gateway_enabled = false
 
-vcn_cidr = "10.0.0.0/16"
+vcn_cidrs = ["10.0.0.0/16", "172.16.0.0/16", "192.168.0.0/24"]
 
 vcn_dns_label = "vcn"
 
 vcn_name = "vcn"
+
+lockdown_default_seclist = false
 
 tags = {
   environment = "dev"

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -64,7 +64,7 @@ variable "internet_gateway_enabled" {
 variable "lockdown_default_seclist" {
   description = "whether to remove all default security rules from the VCN Default Security List"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "nat_gateway_enabled" {
@@ -88,10 +88,10 @@ variable "tags" {
   }
 }
 
-variable "vcn_cidr" {
-  description = "cidr block of VCN"
-  type        = string
-  default     = "10.0.0.0/16"
+variable "vcn_cidrs" {
+  description = "The list of IPv4 CIDR blocks the VCN will use."
+  type        = list(string)
+  default     = ["10.0.0.0/16", "172.16.0.0/16", "192.168.0.0/24"]
 }
 
 variable "vcn_dns_label" {

--- a/variables.tf
+++ b/variables.tf
@@ -81,13 +81,6 @@ variable "service_gateway_enabled" {
   type        = bool
 }
 
-variable "vcn_cidr" {
-  #! Deprecated: please use vcn_cidrs instead
-  description = "DEPRECATED: cidr block of VCN. Please use vcn_cidrs instead."
-  default     = null
-  type        = string
-}
-
 variable "vcn_cidrs" {
   description = "The list of IPv4 CIDR blocks the VCN will use."
   default     = ["10.0.0.0/16"]

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "internet_gateway_enabled" {
 }
 
 variable "local_peering_gateways" {
-  description = "List of Local Peering Gateways to attach to the VCN."
+  description = "Map of Local Peering Gateways to attach to the VCN."
   type        = map(any)
   default     = null
 }
@@ -82,9 +82,16 @@ variable "service_gateway_enabled" {
 }
 
 variable "vcn_cidr" {
-  description = "cidr block of VCN"
-  default     = "10.0.0.0/16"
+  #! Deprecated: please use vcn_cidrs instead
+  description = "DEPRECATED: cidr block of VCN. Please use vcn_cidrs instead."
+  default     = null
   type        = string
+}
+
+variable "vcn_cidrs" {
+  description = "The list of IPv4 CIDR blocks the VCN will use."
+  default     = ["10.0.0.0/16"]
+  type        = list(string)
 }
 
 variable "vcn_dns_label" {

--- a/vcn.tf
+++ b/vcn.tf
@@ -4,7 +4,7 @@
 resource "oci_core_vcn" "vcn" {
   # We still allow module users to declare a cidr using `vcn_cidr` instead of the now recommended `vcn_cidrs`, but internally we map both to `cidr_blocks`
   # The module always use the new list of string structure and let the customer update his module definition block at his own pace. 
-  cidr_blocks    = var.vcn_cidr == null ? var.vcn_cidrs[*] : [var.vcn_cidr]
+  cidr_blocks    = var.vcn_cidrs[*]
   compartment_id = var.compartment_id
   display_name   = var.label_prefix == "none" ? var.vcn_name : "${var.label_prefix}-${var.vcn_name}"
   dns_label      = var.vcn_dns_label

--- a/vcn.tf
+++ b/vcn.tf
@@ -2,7 +2,9 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 resource "oci_core_vcn" "vcn" {
-  cidr_block     = var.vcn_cidr
+  # We still allow module users to declare a cidr using `vcn_cidr` instead of the now recommended `vcn_cidrs`, but internally we map both to `cidr_blocks`
+  # The module always use the new list of string structure and let the customer update his module definition block at his own pace. 
+  cidr_blocks    = var.vcn_cidr == null ? var.vcn_cidrs[*] : [var.vcn_cidr]
   compartment_id = var.compartment_id
   display_name   = var.label_prefix == "none" ? var.vcn_name : "${var.label_prefix}-${var.vcn_name}"
   dns_label      = var.vcn_dns_label

--- a/vcn_defaultresources.tf
+++ b/vcn_defaultresources.tf
@@ -41,13 +41,16 @@ resource "oci_core_default_security_list" "restore_default" {
     }
   }
 
-  ingress_security_rules {
-    //allow all ICMP from VCN
-    protocol = "1"
-    source   = var.vcn_cidr
-
-    icmp_options {
-      type = "3"
+  dynamic "ingress_security_rules" {
+    //allow all ICMP from all VCN CIDRs
+    for_each = oci_core_vcn.vcn.cidr_blocks
+    iterator = vcn_cidr
+    content {
+      protocol = "1"
+      source   = vcn_cidr.value
+      icmp_options {
+        type = "3"
+      }
     }
   }
 


### PR DESCRIPTION
# Proposed change

<!--- 

Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add. Discussing the design upfront helps to ensure that we're ready to accept your work.

The subject of your PR should denote the type of change, i.e: `fix: ...` or `feat: ...`.

Please include a summary of this contribution. If there is an existing issue related to this change, your PR description should auto-link it using these keywords:

- for a bug fix, use `fix` keyword, i.e: `fix #000`
- for a new feature, use `close `keword, i.e: `close #000`

--->

- Fix #21

We still allow module users to declare a VCN cidr_block using <vcn_cidr> instead of the now
recommended <vcn_cidrs>, but internally we map both to <cidr_blocks>.
The module always use the new list of string structure and let the customer update his
module definition block at his own pace.

- Updates all examples to use the new <vcn_cidrs> module Input Variable
instead of the now deprecated <vcn_cidr>.

- Fix #51

## How has these changes been tested?

### Manual testing

If no automated testing is run, please ensure that at least the three steps below are passing without any error.

- [x] Running `terraform apply` on each example provided with this module provisions the intended resource(s) without any errors.
- [x] Modifying module's *Input Variables* after initial provisioning behaves as intended, i.e: any updateable properties are ameneded without recreation of the resource(s).
- [x] Running `terraform destroy` on each example provided with this module destroys all the resources created by this module and only the resources created by this module.

## Checklist before submitting your PR

- [x] My code follows [the style guidelines of this project](../tree/main/docs/codingconventions.adoc)
- [x] these changes provision new resources:
  - [x] I have updated the README introduction section (README.adoc)
  - [x] I have updated the README introduction section (README.md)
- [x] these changes adds any new variables:
  - [x] I have updated [docs/terraformoptions.adoc](../tree/main/docs/terraformoptions.adoc) to include each variable
- [x] I have updated the changelog to include an entry for these changes
- [x] I have updated all provided examples, including each README file and all applicable code blocks
- [x] these changes generates no new warnings
- [x] Any dependent changes have been merged and published in upstream modules

Note: *If you are not an Oracle employee, to contribute to an Oracle-sponsored open-source project, you need to sign the [Oracle Contributor Agreement (OCA)](https://oca.opensource.oracle.com/).*
