### PR TITLE
Makes possible to attach additional or replace default security groups to subnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ provider.tf
 # macOS related files
 **/.DS_Store
 .terraform.lock.hcl
+**/.idea/*

--- a/modules/subnet/data.tf
+++ b/modules/subnet/data.tf
@@ -1,0 +1,3 @@
+data "oci_core_vcn" "vcn_this" {
+  vcn_id = var.vcn_id
+}

--- a/modules/subnet/subnet.tf
+++ b/modules/subnet/subnet.tf
@@ -23,11 +23,10 @@ resource "oci_core_subnet" "vcn_subnet" {
   #prohibit_internet_ingress  = var.enable_ipv6 && lookup(each.value,"type","public") == "public" ? each.value.prohibit_internet_ingress : false
   prohibit_public_ip_on_vnic = lookup(each.value, "type", "public") == "public" ? false : true
   route_table_id             = lookup(each.value, "type", "public") == "public" ? var.ig_route_id : var.nat_route_id
-  security_list_ids          = null
+  security_list_ids          = lookup(each.value, "security_list_ids", null)
 }
 
 data "oci_core_dhcp_options" "dhcp_options" {
-
   compartment_id = var.compartment_id
   vcn_id         = var.vcn_id
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -102,4 +102,5 @@ attached_drg_id = null
 #subnets = {
 #  sub1 = {name = "subnet1",cidr_block = "10.0.4.0/24"}
 #  sub2 = {cidr_block="10.0.5.0/24",type="private"}
+#  sub3 = {cidr_block="10.0.6.0/24",type="private", security_list_ids=["ocid1.securitylist.oc1.eu-frankfurt-1.aaaa","ocid1.securitylist.oc1.eu-frankfurt-1.bbbb"]}
 #}


### PR DESCRIPTION
Makes possible to attach additional or replace default security groups to subnets

Previously worked only with the default security group

Signed-off-by: janis.orlovs <janis@cwise.eu>

# Proposed change

Makes possible to attach additional or replace default security groups to subnets

Previously worked only with the default security group


## How has these changes been tested?

Test deployments works on my location


### Automated testing
NA
### Manual testing

If no automated testing is run, please ensure that at least the three steps below are passing without any error.

- run terraform apply 
- add security group ID based on variables
- terraform destroy

## Checklist before submitting your PR

- [ ] My code follows [the style guidelines of this project](../tree/main/docs/codingconventions.adoc)
- [ ] these changes provision new resources:
  - [ ] I have updated the README introduction section (README.adoc)
  - [ ] I have updated the README introduction section (README.md)
- [ ] these changes adds any new variables:
  - [ ] I have updated [docs/terraformoptions.adoc](../tree/main/docs/terraformoptions.adoc) to include each variable
- [ ] I have updated the changelog to include an entry for these changes
- [ ] I have updated all provided examples, including each README file and all applicable code blocks
- [ ] these changes generates no new warnings
- [ ] Any dependent changes have been merged and published in upstream modules

Note: *If you are not an Oracle employee, to contribute to an Oracle-sponsored open-source project, you need to sign the [Oracle Contributor Agreement (OCA)](https://oca.opensource.oracle.com/).*
