### PR TITLE
fix: Ignore lifecycle changes for defined/freeform tags

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,9 @@ Given a version number MAJOR.MINOR.PATCH:
 - PATCH version when making backwards compatible bug fixes.
 
 == 4.0.0 (not released)
+* Ignored lifecycle changes for defined_tags, freeform_tags
+
+== 3.5.1 (September 5, 2022))
 * removed DRG submodule, now promoted to terraform-oci-drg module (feat: )
 * updated examples to use GitHub repo as source ()
 

--- a/modules/subnet/subnet.tf
+++ b/modules/subnet/subnet.tf
@@ -24,6 +24,10 @@ resource "oci_core_subnet" "vcn_subnet" {
   prohibit_public_ip_on_vnic = lookup(each.value, "type", "public") == "public" ? false : true
   route_table_id             = lookup(each.value, "type", "public") == "public" ? var.ig_route_id : var.nat_route_id
   security_list_ids          = null
+
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
 }
 
 data "oci_core_dhcp_options" "dhcp_options" {

--- a/vcn.tf
+++ b/vcn.tf
@@ -12,6 +12,10 @@ resource "oci_core_vcn" "vcn" {
 
   freeform_tags = var.freeform_tags
   defined_tags  = var.defined_tags
+
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
 }
 
 #Module for Subnet

--- a/vcn_gateways.tf
+++ b/vcn_gateways.tf
@@ -14,6 +14,10 @@ resource "oci_core_internet_gateway" "ig" {
 
   vcn_id = oci_core_vcn.vcn.id
 
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
+
   count = var.create_internet_gateway == true ? 1 : 0
 }
 
@@ -76,6 +80,10 @@ resource "oci_core_route_table" "ig" {
 
   vcn_id = oci_core_vcn.vcn.id
 
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
+
   count = var.create_internet_gateway == true ? 1 : 0
 }
 
@@ -103,6 +111,10 @@ resource "oci_core_service_gateway" "service_gateway" {
 
   vcn_id = oci_core_vcn.vcn.id
 
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
+
   count = var.create_service_gateway == true ? 1 : 0
 }
 
@@ -119,6 +131,10 @@ resource "oci_core_nat_gateway" "nat_gateway" {
   public_ip_id = var.nat_gateway_public_ip_id != "none" ? var.nat_gateway_public_ip_id : null
 
   vcn_id = oci_core_vcn.vcn.id
+
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
 
   count = var.create_nat_gateway == true ? 1 : 0
 }
@@ -195,6 +211,10 @@ resource "oci_core_route_table" "nat" {
 
   vcn_id = oci_core_vcn.vcn.id
 
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
+
   count = var.create_nat_gateway == true ? 1 : 0
 }
 
@@ -217,4 +237,8 @@ resource "oci_core_local_peering_gateway" "lpg" {
   #Optional
   peer_id        = can(each.value.peer_id) == false ? null : each.value.peer_id
   route_table_id = can(each.value.route_table_id) == false ? null : each.value.route_table_id
+
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
 }


### PR DESCRIPTION
# Proposed change

Ignore lifecycle changes for `defined_tags` and `freeform_tags` on the resources that declare them, to prevent reported changes on each apply.

```
  # module.vcn[0].oci_core_vcn.vcn will be updated in-place
  ~ resource "oci_core_vcn" "vcn" {
      ~ defined_tags             = {
          - "Oracle-Tags.CreatedBy" = "..." -> null
          - "Oracle-Tags.CreatedOn" = "2022-10-07T20:00:43.179Z" -> null
```

## How has these changes been tested?

Plan looks good, remaining tests pending:
- [ ] Running `terraform apply` on each example provided with this module provisions the intended resource(s) without any errors.
- [ ] Modifying module's *Input Variables* after initial provisioning behaves as intended, i.e: any updateable properties are amended without recreation of the resource(s).
- [ ] Running `terraform destroy` on each example provided with this module destroys all the resources created by this module and only the resources created by this module.

## Checklist before submitting your PR

- [x] My code follows [the style guidelines of this project](../tree/main/docs/codingconventions.adoc)
- [ ] ~~these changes provision new resources:~~
  - [ ] ~~I have updated the README introduction section (README.adoc)~~
  - [ ] ~~I have updated the README introduction section (README.md)~~
- [ ] ~~these changes adds any new variables:~~
  - [ ] ~~I have updated [docs/terraformoptions.adoc](../tree/main/docs/terraformoptions.adoc) to include each variable~~
- [x] I have updated the changelog to include an entry for these changes
- [ ] ~~I have updated all provided examples, including each README file and all applicable code blocks~~
- [x] these changes generates no new warnings
- [x] Any dependent changes have been merged and published in upstream modules