### PR TITLE
feat: Support disabled DNS resolution with optional dns_label on VCN

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ Given a version number MAJOR.MINOR.PATCH:
 
 == 4.0.0 (not released)
 * Added support for disabled VCN DNS resolution with null vcn_dns_label variable
+* Change default vcn_name from vcn-module -> vcn
 
 == 3.5.2 (October 7, 2022)
 * Ignored lifecycle changes for defined_tags, freeform_tags

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,9 +15,12 @@ Given a version number MAJOR.MINOR.PATCH:
 - PATCH version when making backwards compatible bug fixes.
 
 == 4.0.0 (not released)
+* Added support for disabled VCN DNS resolution with null vcn_dns_label variable
+
+== 3.5.2 (October 7, 2022)
 * Ignored lifecycle changes for defined_tags, freeform_tags
 
-== 3.5.1 (September 5, 2022))
+== 3.5.1 (September 5, 2022)
 * removed DRG submodule, now promoted to terraform-oci-drg module (feat: )
 * updated examples to use GitHub repo as source ()
 

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -91,7 +91,6 @@ variable "user_id" {
 
 * `compartment_id`
 * `label_prefix`
-* `vcn_dns_label`
 * `vcn_name`
 
 . Optional parameters to override:
@@ -101,6 +100,7 @@ variable "user_id" {
 * `create_service_gateway`
 * `freeform_tags`
 * `attached_drg_id`
+* `vcn_dns_label`
 
 . Run Terraform:
 
@@ -160,7 +160,6 @@ cp terraform.tfvars.example terraform.tfvars
 
 * `compartment_id`
 * `label_prefix`
-* `vcn_dns_label`
 * `vcn_name`
 
 . Optional parameters to override:
@@ -171,6 +170,7 @@ cp terraform.tfvars.example terraform.tfvars
 * `create_service_gateway`
 * `freeform_tags`
 * `defined_tags`
+* `vcn_dns_label`
 
 . Run Terraform:
 +

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -225,7 +225,7 @@ e.g.
 |`vcn_name`
 |The name of the VCN that will be appended to the label_prefix.
 |`string`
-|"vcn-module"
+|"vcn"
 
 |===
 

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -218,14 +218,14 @@ e.g.
 | `["10.0.0.0/16"]`
 
 |`vcn_dns_label`
-|A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet
+|A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet. DNS resolution for hostnames in the VCN is disabled if null.
 |`string`
 |"vcnmodule"
 
 |`vcn_name`
-|The name of the VCN that will be appended to the label_prefix. *Required*
+|The name of the VCN that will be appended to the label_prefix.
 |`string`
-|
+|"vcn-module"
 
 |===
 

--- a/examples/custom_route_rules/variables.tf
+++ b/examples/custom_route_rules/variables.tf
@@ -110,7 +110,7 @@ variable "vcn_dns_label" {
 variable "vcn_name" {
   description = "user-friendly name of to use for the vcn to be appended to the label_prefix"
   type        = string
-  default     = "vcn-module"
+  default     = "vcn"
 }
 
 # gateways parameters

--- a/examples/hub-spoke/variables.tf
+++ b/examples/hub-spoke/variables.tf
@@ -109,7 +109,7 @@ variable "vcn_dns_label" {
 variable "vcn_name" {
   description = "user-friendly name of to use for the vcn to be appended to the label_prefix"
   type        = string
-  default     = "vcn-module"
+  default     = "vcn"
 }
 
 # gateways parameters

--- a/examples/module_composition/variables.tf
+++ b/examples/module_composition/variables.tf
@@ -109,7 +109,7 @@ variable "vcn_dns_label" {
 variable "vcn_name" {
   description = "user-friendly name of to use for the vcn to be appended to the label_prefix"
   type        = string
-  default     = "vcn-module"
+  default     = "vcn"
 }
 
 # gateways parameters

--- a/modules/subnet/subnet.tf
+++ b/modules/subnet/subnet.tf
@@ -26,7 +26,7 @@ resource "oci_core_subnet" "vcn_subnet" {
   security_list_ids          = null
 
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, dns_label, freeform_tags]
   }
 }
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -46,7 +46,7 @@ variables:
   vcn_dns_label:
     title: VCN DNS Label
     type: string
-    required: true
+    required: false
     default: vcn
 
   lockdown_default_seclist:

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright (c) 2019, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # provider identity parameters
@@ -83,13 +83,13 @@ variable "vcn_cidrs" {
 }
 
 variable "vcn_dns_label" {
-  description = "A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet"
+  description = "A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet. DNS resolution of hostnames in the VCN is disabled when null."
   type        = string
   default     = "vcnmodule"
 
   validation {
-    condition     = length(regexall("^[^0-9][a-zA-Z0-9_]+$", var.vcn_dns_label)) > 0
-    error_message = "DNS label must be an alphanumeric string that begins with a letter."
+    condition     = var.vcn_dns_label == null ? true : length(regexall("^[^0-9][a-zA-Z0-9_]{1,14}$", var.vcn_dns_label)) > 0
+    error_message = "DNS label must be unset to disable, or an alphanumeric string with length of 1 through 15 that begins with a letter."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "vcn_dns_label" {
 variable "vcn_name" {
   description = "user-friendly name of to use for the vcn to be appended to the label_prefix"
   type        = string
-  default     = "vcn-module"
+  default     = "vcn"
   validation {
     condition     = length(var.vcn_name) > 0
     error_message = "The vcn_name value cannot be an empty string."

--- a/vcn.tf
+++ b/vcn.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2021, Oracle Corporation and/or affiliates.
+# Copyright (c) 2019, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 resource "oci_core_vcn" "vcn" {
@@ -14,7 +14,7 @@ resource "oci_core_vcn" "vcn" {
   defined_tags  = var.defined_tags
 
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, dns_label, freeform_tags]
   }
 }
 


### PR DESCRIPTION
# Proposed change

Allow null value for vcn_dns_label input variable with optional [core_vcn#dns_label](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn#dns_label).

```
vcn_dns_label = null
```

> DNS Domain Name: DNS isn’t enabled for this VCN
> DNS Domain Name: DNS isn’t enabled for this Subnet

## How has these changes been tested?

Manually, on new and existing tfstate with null and default values.

### Manual testing

If no automated testing is run, please ensure that at least the three steps below are passing without any error.

- [x] Running `terraform apply` on each example provided with this module provisions the intended resource(s) without any errors.
- [x] Modifying module's *Input Variables* after initial provisioning behaves as intended, i.e: any updateable properties are amended without recreation of the resource(s).
- [x] Running `terraform destroy` on each example provided with this module destroys all the resources created by this module and only the resources created by this module.

## Checklist before submitting your PR

- [x] My code follows [the style guidelines of this project](../tree/main/docs/codingconventions.adoc)
- [x] I have updated the changelog to include an entry for these changes
- [x] I have updated all provided examples, including each README file and all applicable code blocks
- [x] these changes generates no new warnings
- [x] Any dependent changes have been merged and published in upstream modules
