### PR TITLE
Separate Service Gateway routing rule from NAT

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,11 @@ output "nat_route_id" {
   value       = join(",", oci_core_route_table.nat[*].id)
 }
 
+output "sgw_route_id" {
+  description = "id of VCN Service gateway route table"
+  value       = join(",", oci_core_route_table.service_gw[*].id)
+}
+
 # New complete outputs for each resources with provider parity. Auto-updating.
 # Usefull for module composition.
 


### PR DESCRIPTION
Service Gateway routing rule is baked into the NAT routing table.
If the NAT gateway is disabled (`create_nat_gateway = false`) then there would be no routing rule for the Service gateway.


This change separates the Service Gateway routing rule from NAT rules.

Closes: #108
